### PR TITLE
Add 'io' module

### DIFF
--- a/testwatch/io.py
+++ b/testwatch/io.py
@@ -31,3 +31,7 @@ def confirm(prompt):
 
 def info(s):
     print(s)
+
+
+def error(s):
+    print(s)


### PR DESCRIPTION
This PR adds an `io` module to `testwatch`. It contains a collection of utility functions that handle input and output on a low level of abstraction.