### PR TITLE
Add 'store' module

### DIFF
--- a/testwatch/store.py
+++ b/testwatch/store.py
@@ -38,5 +38,17 @@ def _handle_session_file():
         io.info('Last session file is loaded.')
 
 
+def add_entry(timestamp, entry_type, entry_content):
+    if '\t' in entry_content:
+        io.error(
+            "Tabs are not allowed in entry's content. "
+            "Last entry was not registered."
+        )
+        return
+
+    with open(SESSION_FILE, 'a') as f:
+        f.write(f'{timestamp}\t{entry_type}\t{entry_content}\n')
+
+
 def last_entry():
     return _last_entry


### PR DESCRIPTION
This PR adds a `store` module to `testwatch`. Its purpose is to store data created and used by `testwatch`.