### PR TITLE
Update 'last_entry' when the new one is added

### DIFF
--- a/testwatch/store.py
+++ b/testwatch/store.py
@@ -62,6 +62,9 @@ def add_entry(timestamp, entry_type, entry_content):
     with open(SESSION_FILE, 'a') as f:
         f.write(f'{timestamp}\t{entry_type}\t{entry_content}\n')
 
+    global _last_entry
+    _last_entry = Entry(timestamp, entry_type, entry_content)
+
 
 def last_entry():
     return _last_entry


### PR DESCRIPTION
This PR fixes a bug that occurred when a new entry had been added but the value of `last_entry` was unchanged.