### PR TITLE
Add 'io.raw' function

### DIFF
--- a/testwatch/io.py
+++ b/testwatch/io.py
@@ -32,6 +32,10 @@ def confirm(prompt):
 #
 
 
+def raw(s):
+    print(s)
+
+
 def info(s):
     print(s)
 


### PR DESCRIPTION
This PR adds a `raw` function to `io` module. It prints text without any formatting.